### PR TITLE
Fix auth

### DIFF
--- a/gabiv2/gasket.ts
+++ b/gabiv2/gasket.ts
@@ -60,14 +60,7 @@ export default makeGasket({
       market: "en-us", // Locale you are attempting to render for.
       theme: "GoDaddy-dark", // CSS4 theme (default is `godaddy:brand` based on private label id)
       tealium: false,
-      traffic: "disable",
-      privateLabel: 1,
-      brand: 3,
-      local: false,
-      uxcore: false,
-      delayjs: false, // **DEPRECATED** Defaults (false): Delay's loading of the header for faster perceived load.
-      deferjs: false,
-      optOut: false,
+      traffic: "disable"
     },
   },
   data: gasketData,

--- a/gabiv2/package-lock.json
+++ b/gabiv2/package-lock.json
@@ -2683,6 +2683,84 @@
         "http-proxy": "^1.18.1"
       }
     },
+    "node_modules/@gasket/plugin-intl": {
+      "version": "7.2.2",
+      "resolved": "https://gdartifactory1.jfrog.io/artifactory/api/npm/node-virt/@gasket/plugin-intl/-/plugin-intl-7.2.2.tgz",
+      "integrity": "sha512-Cs1kznMIelvZeSwy9ysGLroHitFzD0J1KQWcIPEjaVWrKhOeBC/a67oxOxcLq61VZinTC7zxxkARmYoiqyLlEQ==",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "@gasket/request": "^7.2.0",
+        "debug": "^4.3.4",
+        "fs-extra": "^10.0.0",
+        "glob": "^8.1.0",
+        "intl": "^1.2.5",
+        "negotiator": "^1.0.0",
+        "semver": "^7.6.3"
+      }
+    },
+    "node_modules/@gasket/plugin-intl/node_modules/fs-extra": {
+      "version": "10.1.0",
+      "resolved": "https://gdartifactory1.jfrog.io/artifactory/api/npm/node-virt/fs-extra/-/fs-extra-10.1.0.tgz",
+      "integrity": "sha512-oRXApq54ETRj4eMiFzGnHWGy+zo5raudjuxN0b8H7s/RU2oW0Wvsx9O0ACRN/kRq9E8Vu/ReskGB5o3ji+FzHQ==",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "graceful-fs": "^4.2.0",
+        "jsonfile": "^6.0.1",
+        "universalify": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@gasket/plugin-intl/node_modules/glob": {
+      "version": "8.1.0",
+      "resolved": "https://gdartifactory1.jfrog.io/artifactory/api/npm/node-virt/glob/-/glob-8.1.0.tgz",
+      "integrity": "sha512-r8hpEjiQEYlF2QU0df3dS+nxxSIreXQS1qRhMJM0Q5NDdR386C7jb7Hwwod8Fgiuex+k0GFjgft18yvxm5XoCQ==",
+      "deprecated": "Glob versions prior to v9 are no longer supported",
+      "license": "ISC",
+      "peer": true,
+      "dependencies": {
+        "fs.realpath": "^1.0.0",
+        "inflight": "^1.0.4",
+        "inherits": "2",
+        "minimatch": "^5.0.1",
+        "once": "^1.3.0"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/@gasket/plugin-intl/node_modules/minimatch": {
+      "version": "5.1.6",
+      "resolved": "https://gdartifactory1.jfrog.io/artifactory/api/npm/node-virt/minimatch/-/minimatch-5.1.6.tgz",
+      "integrity": "sha512-lKwV/1brpG6mBUFHtb7NUmtABCb2WZZmm2wNiOA5hAb8VdCS4B3dtMWyvcoViccwAW/COERjXLt0zP1zXUN26g==",
+      "license": "ISC",
+      "peer": true,
+      "dependencies": {
+        "brace-expansion": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/@gasket/plugin-intl/node_modules/semver": {
+      "version": "7.7.1",
+      "resolved": "https://gdartifactory1.jfrog.io/artifactory/api/npm/node-virt/semver/-/semver-7.7.1.tgz",
+      "integrity": "sha512-hlq8tAfn0m/61p4BVRcPzIGr6LKiMwo4VM6dGi6pt4qcRkmNzTcWq6eCEjEh+qXjkMDvPlOFFSGwQjoEa6gyMA==",
+      "license": "ISC",
+      "peer": true,
+      "bin": {
+        "semver": "bin/semver.js"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
     "node_modules/@gasket/plugin-logger": {
       "version": "7.2.1",
       "resolved": "https://gdartifactory1.jfrog.io/artifactory/api/npm/node-virt/@gasket/plugin-logger/-/plugin-logger-7.2.1.tgz",
@@ -9008,7 +9086,7 @@
       "version": "4.0.3",
       "resolved": "https://gdartifactory1.jfrog.io/artifactory/api/npm/node-virt/chokidar/-/chokidar-4.0.3.tgz",
       "integrity": "sha512-Qgzu8kfBvo+cA4962jnP1KkS6Dop5NS6g7R5LFYJr4b8Ub94PPQXUksCw9PvXoeXPRRddRNC5C1JQUR2SMGtnA==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "readdirp": "^4.0.1"
@@ -12887,7 +12965,7 @@
       "version": "5.0.3",
       "resolved": "https://gdartifactory1.jfrog.io/artifactory/api/npm/node-virt/immutable/-/immutable-5.0.3.tgz",
       "integrity": "sha512-P8IdPQHq3lA1xVeBRi5VPqUm5HDgKnx0Ru51wZz5mjxHr5n3RWhjIpOFU7ybkUxfB+5IToy+OLaHYDBIWsv+uw==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT"
     },
     "node_modules/import-fresh": {
@@ -13052,6 +13130,13 @@
       "engines": {
         "node": ">= 0.4"
       }
+    },
+    "node_modules/intl": {
+      "version": "1.2.5",
+      "resolved": "https://gdartifactory1.jfrog.io/artifactory/api/npm/node-virt/intl/-/intl-1.2.5.tgz",
+      "integrity": "sha512-rK0KcPHeBFBcqsErKSpvZnrOmWOj+EmDkyJ57e90YWaQNqbcivcqmKDlHEeNprDWOsKzPsh1BfSpPQdDvclHVw==",
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/intl-messageformat": {
       "version": "10.5.14",
@@ -17671,7 +17756,7 @@
       "version": "4.1.1",
       "resolved": "https://gdartifactory1.jfrog.io/artifactory/api/npm/node-virt/readdirp/-/readdirp-4.1.1.tgz",
       "integrity": "sha512-h80JrZu/MHUZCyHu5ciuoI0+WxsCxzxJTILn6Fs8rxSnFPh+UVHYfeIxK1nVGugMqkfC4vJcBOYbkfkwYK0+gw==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "engines": {
         "node": ">= 14.18.0"
@@ -18146,7 +18231,7 @@
       "version": "1.84.0",
       "resolved": "https://gdartifactory1.jfrog.io/artifactory/api/npm/node-virt/sass/-/sass-1.84.0.tgz",
       "integrity": "sha512-XDAbhEPJRxi7H0SxrnOpiXFQoUJHwkR2u3Zc4el+fK/Tt5Hpzw5kkQ59qVDfvdaUq6gCrEZIbySFBM2T9DNKHg==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "chokidar": "^4.0.0",
@@ -19993,7 +20078,6 @@
       "version": "5.7.3",
       "resolved": "https://gdartifactory1.jfrog.io/artifactory/api/npm/node-virt/typescript/-/typescript-5.7.3.tgz",
       "integrity": "sha512-84MVSjMEHP+FQRPy3pX9sTVV/INIex71s9TL2Gm5FG/WG1SqXeKyZ0k7/blY/4FdOzI12CBy1vGc4og/eus0fw==",
-      "dev": true,
       "license": "Apache-2.0",
       "bin": {
         "tsc": "bin/tsc",

--- a/gabiv2/pages/_app.tsx
+++ b/gabiv2/pages/_app.tsx
@@ -18,11 +18,15 @@ function Layout(props) {
 
 const App = createApp({ Layout, initialProps: true });
 
-// Wrap the app with higher-order components
 const authRequired = withAuthRequired({
   realm: "jomax",
   gasket,
 });
-export default withPageEnhancers([authRequired])(App);
+
+// Wrap the app with higher-order components
+export default [
+  withPageEnhancers([authRequired]),
+  withAuthProvider(),
+].reduce((cmp, hoc) => hoc(cmp), App);
 
 export { reportWebVitals };


### PR DESCRIPTION
Gasket auth uses React Context to make auth checks easily available to other components. This includes page components if you want to check at the Page level. Additionally, the Gasket plugins have PresentationCentral default settings to tune your app for speed.

- Add missing `withAuthProvider` to get the app working with auth
- Adjust presentationCentral config to keep optimizations

```
cd gabiv2
npm ci
npm run local
```

![Screenshot 2025-02-10 at 1 47 16 PM](https://github.com/user-attachments/assets/fdcebdd6-a896-4c82-9bf0-af50bf4e2107)
